### PR TITLE
remove hard coded import path to mirror module main

### DIFF
--- a/src/settings/modules/support/support.scss
+++ b/src/settings/modules/support/support.scss
@@ -1,4 +1,4 @@
-@import "src/settings/constants.scss";
+@import "../../constants.scss";
 
 .support-tab {
 


### PR DESCRIPTION
moving into a resource directory in a Laravel project, I had to track down this hard coded path. Might be nice to mirror the ../../ structure from main.scss
