### PR TITLE
added https:true to the webpack server config

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,8 @@ var config = require('./webpack.config');
 new WebpackDevServer(webpack(config), {
     publicPath: config.output.publicPath,
     hot: true,
-    historyApiFallback: true
+    historyApiFallback: true,
+    https: true	
 }).listen(3000, 'localhost', function (err, result) {
     if (err) {
         return console.log(err);


### PR DESCRIPTION
As the widget and setting URLs must be over HTTPs, I've added it to the default webpack config, to save time from developers when they set it up.